### PR TITLE
Change dependencies to use stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,9 @@
             "email": "sam.stenvall@nordsoftware.com"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
-        "league/flysystem": "^1.1@dev",
-        "league/flysystem-aws-s3-v2": "^1.0@dev"
+        "league/flysystem": "^1.0.27",
+        "league/flysystem-aws-s3-v2": "^1.0.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I doubt we really need the bleeding edge version of league/flysystem.

This enables use of this library without using `minimum-stability: dev`.
